### PR TITLE
Fix issue in copy files script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ WebViewer.zip
 /dist
 /tmp
 /out-tsc
-public/webviewer
 
 # dependencies
 /node_modules

--- a/angular.json
+++ b/angular.json
@@ -25,9 +25,6 @@
             ],
             "styles": [
               "src/styles.css"
-            ],
-            "scripts": [
-              "src/lib/webviewer.min.js"
             ]
           },
           "configurations": {

--- a/tools/copy-webviewer-files.js
+++ b/tools/copy-webviewer-files.js
@@ -1,12 +1,16 @@
 const fs = require('fs-extra');
+const path = require('path');
 
 const copyFiles = async () => {
+  const sourcePath = path.resolve('./node_modules/@pdftron/webviewer/public');
+  const destPath = path.resolve('./src/lib/');
+
   try {
-    await fs.copy('./node_modules/@pdftron/webviewer/public', './public/webviewer/lib');
+    await fs.copy(sourcePath, destPath);
     console.log('WebViewer files copied over successfully');
   } catch (err) {
     console.error(err);
   }
 };
 
-copyFiles();å
+copyFiles();


### PR DESCRIPTION
A weird character somehow made it onto the copy file script; remove that and also the import for webviwer.min.js as we now use the NPM package