### PR TITLE
Updating code to use object destructuring

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -43,10 +43,8 @@ export class AppComponent implements OnInit, AfterViewInit {
 
   wvDocumentLoadedHandler(): void {
     // you can access docViewer object for low-level APIs
-    const docViewer = this.wvInstance;
-    const annotManager = this.wvInstance.annotManager;
     // and access classes defined in the WebViewer iframe
-    const { Annotations } = this.wvInstance;
+    const { Annotations, annotManager, docViewer } = this.wvInstance;
     const rectangle = new Annotations.RectangleAnnotation();
     rectangle.PageNumber = 1;
     rectangle.X = 100;


### PR DESCRIPTION
One thing that was bugging me when using the sample was how we did object destructuring on one line, but would access the other properties one by one.

Also docViewer should have been set to `this.vwInstance.docViewer` and not the instance itself.